### PR TITLE
[조형민] refactor: react hook form에 zod를 적용하여 유효성 체크

### DIFF
--- a/components/molecules/InputEmail.tsx
+++ b/components/molecules/InputEmail.tsx
@@ -1,4 +1,3 @@
-import defaultRules from '@/constants/formValidation';
 import React from 'react';
 import { FieldPath, FieldValues, UseControllerProps } from 'react-hook-form';
 import Input from '../atoms/Input';
@@ -20,9 +19,7 @@ function InputEmail<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
 >({ label, ...props }: Props & UseControllerProps<TFieldValues, TName>) {
-  return (
-    <Input label={label} type="email" rules={defaultRules.email} {...props} />
-  );
+  return <Input label={label} type="email" {...props} />;
 }
 
 export default InputEmail;

--- a/components/molecules/InputPassword.tsx
+++ b/components/molecules/InputPassword.tsx
@@ -1,6 +1,5 @@
 import icVisibilityOn from '@/assets/images/ic-visibility-on.svg';
 import icVisibility from '@/assets/images/ic-visibility.svg';
-import defaultRules from '@/constants/formValidation';
 import Image from 'next/image';
 import React, { useState } from 'react';
 import { FieldPath, FieldValues, UseControllerProps } from 'react-hook-form';
@@ -33,7 +32,6 @@ function InputPassword<
       <Input
         label={label}
         type={`${!isShowPassword ? 'password' : 'text'}`}
-        rules={defaultRules.password}
         {...props}
       />
       <Image

--- a/components/molecules/InputText.tsx
+++ b/components/molecules/InputText.tsx
@@ -1,4 +1,3 @@
-import defaultRules from '@/constants/formValidation';
 import React from 'react';
 import { FieldPath, FieldValues, UseControllerProps } from 'react-hook-form';
 import Input from '../atoms/Input';
@@ -20,7 +19,7 @@ function InputText<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
 >({ label, ...props }: Props & UseControllerProps<TFieldValues, TName>) {
-  return <Input label={label} rules={defaultRules.text} {...props} />;
+  return <Input label={label} {...props} />;
 }
 
 export default InputText;

--- a/components/organisms/FormLogin.tsx
+++ b/components/organisms/FormLogin.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { logInValidation } from '@/constants/formValidation';
 import { UserLogInDto } from '@/types/dtos/user.dto';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import TempAuthRegistButton from '../atoms/TempAuthRegistButton';
 import InputEmail from '../molecules/InputEmail';
@@ -19,6 +21,7 @@ function FormLogIn() {
   const { control, handleSubmit, formState } = useForm<FormLogInInput>({
     defaultValues: { email: '', password: '' },
     mode: 'onBlur',
+    resolver: zodResolver(logInValidation),
   });
   return (
     <div className="w-full flex justify-center">

--- a/components/organisms/FormSignUp.tsx
+++ b/components/organisms/FormSignUp.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import defaultRules from '@/constants/formValidation';
+import { signUpValidation } from '@/constants/formValidation';
 import { UserSignUpDto } from '@/types/dtos/user.dto';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import TempAuthRegistButton from '../atoms/TempAuthRegistButton';
 import InputEmail from '../molecules/InputEmail';
@@ -21,17 +22,17 @@ const handleClickSignUp = (inputData: UserSignUpDto) => {
 };
 
 function FormSignUp() {
-  const { control, handleSubmit, getValues, formState } =
-    useForm<FormSignUpInput>({
-      defaultValues: {
-        email: '',
-        name: '',
-        phoneNumber: '',
-        password: '',
-        passwordConfirm: '',
-      },
-      mode: 'onBlur',
-    });
+  const { control, handleSubmit, formState } = useForm<FormSignUpInput>({
+    defaultValues: {
+      email: '',
+      name: '',
+      phoneNumber: '',
+      password: '',
+      passwordConfirm: '',
+    },
+    mode: 'onBlur',
+    resolver: zodResolver(signUpValidation),
+  });
 
   return (
     <form
@@ -58,7 +59,6 @@ function FormSignUp() {
         id="phoneNumber"
         label="휴대 전화번호"
         placeholder="휴대 전화번호 형식에 맞게 입력해 주세요"
-        rules={defaultRules.phoneNumber}
       />
       <InputPassword
         name="password"
@@ -73,21 +73,6 @@ function FormSignUp() {
         id="passwordConfirm"
         label="비밀번호 확인"
         placeholder="비밀번호를 다시 한 번 입력해 주세요"
-        rules={{
-          required: '필수 입력 항목입니다',
-          validate: {
-            isPasswordNotMatch: () => {
-              const {
-                password: passwordValue,
-                passwordConfirm: passwordConfirmValue,
-              } = getValues();
-              return (
-                passwordValue === passwordConfirmValue ||
-                '비밀번호가 일치하지 않습니다'
-              );
-            },
-          },
-        }}
       />
       <TempAuthRegistButton isValid={formState.isValid}>
         회원가입

--- a/constants/formValidation.ts
+++ b/constants/formValidation.ts
@@ -1,39 +1,47 @@
-const email = {
-  required: '필수 입력 항목입니다',
-  pattern: {
-    value:
-      /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i,
-    message: '잘못된 이메일 형식입니다',
-  },
-};
+import { z } from 'zod';
 
-const password = {
-  required: '필수 입력 항목입니다',
-  pattern: {
-    value:
-      /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+~`\-={}[\]:;"'<>,.?/\\]).{8,}$/,
-    message: '최소 8자 이상, 영문/숫자/특수문자를 모두 포함해야 합니다',
-  },
-};
+const requiredStr: string = '필수 입력 항목입니다';
+const phoneNumberRegex = new RegExp(/^(01[016789]{1})[0-9]{3,4}[0-9]{4}$/);
+const passwordRegex = new RegExp(
+  /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+~`\-={}[\]:;"'<>,.?/\\]).{8,}$/
+);
 
-const text = {
-  required: '필수 입력 항목입니다',
-};
+export const logInValidation = z.object({
+  email: z
+    .string()
+    .min(1, { message: requiredStr })
+    .email({ message: '잘못된 이메일 형식입니다' }),
+  password: z.string().min(1, { message: requiredStr }),
+});
 
-const phoneNumber = {
-  required: '필수 입력 항목입니다',
-  pattern: {
-    value: /^(01[016789]{1})[0-9]{3,4}[0-9]{4}$/,
-
-    message: '잘못된 전화번호 형식입니다',
-  },
-};
-
-const defaultRules = {
-  email,
-  password,
-  text,
-  phoneNumber,
-};
-
-export default defaultRules;
+export const signUpValidation = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, { message: requiredStr })
+      .min(2, { message: '두 글자 이상이어야 합니다' }),
+    email: z
+      .string()
+      .min(1, { message: requiredStr })
+      .email({ message: '잘못된 이메일 형식입니다' }),
+    phoneNumber: z
+      .string()
+      .min(1, { message: requiredStr })
+      .regex(phoneNumberRegex, '잘못된 전화번호 형식입니다'),
+    password: z
+      .string()
+      .min(1, { message: requiredStr })
+      .min(8, { message: '최소 8자 이상이어야 합니다' })
+      .regex(passwordRegex, '영문/숫자/특수문자를 모두 포함해야 합니다'),
+    passwordConfirm: z.string(),
+  })
+  .superRefine(({ password, passwordConfirm }, ctx) => {
+    if (password !== passwordConfirm) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom, // code: 'custom'으로 적어도 무방
+        message: '비밀번호가 일치하지 않습니다',
+        path: ['passwordConfirm'], // 에러 메시지가 표시될 위치 지정(여러 곳에서 메시지를 표시하려면 addIssue를 추가)
+      });
+    }
+  });

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -32,8 +32,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // 로그인된 상태에서 로그인 또는 회원가입 페이지에 접근하면 마켓플레이스(홈) 페이지로 이동
   useEffect(() => {
+    console.log(isLoggedIn, pathName);
     if (
       isLoggedIn &&
+      // (pathName.startsWith('/auth/sign-up') ||
+      //   pathName.startsWith('/auth/log-in'))
       (pathName === '/auth/sign-up' || pathName === '/auth/log-in')
     ) {
       router.replace('/');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,15 @@
       "name": "moving",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^4.1.3",
         "@tanstack/react-query": "^5.69.0",
         "axios": "^1.8.4",
         "clsx": "^2.1.1",
         "next": "15.2.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-hook-form": "^7.54.2"
+        "react-hook-form": "^7.54.2",
+        "zod": "^3.24.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -211,6 +213,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-4.1.3.tgz",
+      "integrity": "sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -857,6 +871,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -5862,6 +5882,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^4.1.3",
     "@tanstack/react-query": "^5.69.0",
     "axios": "^1.8.4",
     "clsx": "^2.1.1",
     "next": "15.2.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hook-form": "^7.54.2"
+    "react-hook-form": "^7.54.2",
+    "zod": "^3.24.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
### React hook form에 zod를 적용하여 유효성 체크
**완전 좋습니다. 단점은 없고 장점만 있습니다. 장점을 정리해 봅니다.**
- react hook form에 적용이 간편합니다. useForm선언부에 아래 코드 한 줄만 추가! (찰떡 궁합!!!)
<img width="414" alt="image" src="https://github.com/user-attachments/assets/1d5522e4-a493-48b2-9991-83982ef510d1" />

- 컴포넌트별로 rules를 적용할 필요가 없고 폼의 항목 전체 validation을 객체로 정의할 수 있습니다.
  - 그런 이유로 InputEmail, InputPassword 등에 rules prop을 정의할 필요가 없습니다.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/9551c3b1-f11d-4809-8124-9e1f02153416" />

- 내장된 검증 함수가 다양하여 코드가 간결해지고 필요한 경우 정규식을 사용할 수도 있습니다.
  - 핸드폰 번호, 비밀번호는 아래와 같이 정규식을 적용하였습니다.
<img width="705" alt="image" src="https://github.com/user-attachments/assets/c5d34ca1-f478-4d40-9c46-4ede35fc3fde" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/ba26dab1-4c9e-4c15-a534-7c1926b03f52" />

- 체이닝을 통해서 여러 조건을 단계별로 체크하는 것이 간편합니다.
- 특정 폼에서 에러 발생 시 그 폼 뿐만 아니라 다른 폼에서도 간편하게 에러를 발생시킬 수 있습니다. (superRefine의 ctx를 통해 가능)