### PR TITLE
[조형민] queryClient 생성 방식 변경, '찜한 기사님' 페이지 구현, Gnb 알림/프로필 팝업 메뉴 구현 등

### DIFF
--- a/app/(providers)/(root)/customer/favorites/page.tsx
+++ b/app/(providers)/(root)/customer/favorites/page.tsx
@@ -13,7 +13,7 @@ async function FavoriteWorkersPage() {
   return (
     <HydrationBoundary state={dehydrate(favoritesQueryClient)}>
       <div className="bg-BackGround-200 min-h-full">
-        <div className="flex justify-center items-center w-full bg-GrayScale-50 h-24">
+        <div className="flex justify-center items-center w-full bg-GrayScale-50 h-24 mb-6">
           <div className="w-[1400px]">
             <Label intent="md">찜한 기사님</Label>
           </div>

--- a/app/(providers)/layout.tsx
+++ b/app/(providers)/layout.tsx
@@ -22,11 +22,6 @@ async function ProvidersLayout({ children }: { children: ReactNode }) {
       queryFn: () => getUserMeServer(accessToken),
     });
   }
-  const dehydratedState = dehydrate(userQueryClient);
-  console.log(
-    '🧊 SSR dehydratedState',
-    JSON.stringify(dehydratedState, null, 2)
-  );
   return (
     <TanstackQueryProvider>
       <HydrationBoundary state={dehydrate(userQueryClient)}>

--- a/components/atoms/IconAlarm.tsx
+++ b/components/atoms/IconAlarm.tsx
@@ -1,0 +1,19 @@
+import icAlarm from '@/assets/images/ic-alarm.svg';
+import Image from 'next/image';
+
+interface Props {
+  onClick: () => void;
+}
+
+function IconAlarm({ onClick }: Props) {
+  return (
+    <Image
+      src={icAlarm}
+      alt="알림"
+      className="w-6 h-6 lg:w-9 lg:h-9 cursor-pointer hover:opacity-60 active:opacity-40"
+      onClick={onClick}
+    />
+  );
+}
+
+export default IconAlarm;

--- a/components/atoms/LoadingSpinner.tsx
+++ b/components/atoms/LoadingSpinner.tsx
@@ -20,7 +20,6 @@ const sizeMap = {
  */
 function LoadingSpinner({ size = 'md' }: Props) {
   const sizeClassName = sizeMap[size];
-  console.log(sizeClassName);
   return (
     <div className="text-center mt-30">
       <div role="status">

--- a/components/atoms/LoadingSpinner.tsx
+++ b/components/atoms/LoadingSpinner.tsx
@@ -1,0 +1,50 @@
+interface Props {
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const sizeMap = {
+  sm: 'w-20 h-20',
+  md: 'w-30 h-30',
+  lg: 'w-40 h-40',
+};
+
+/**
+ *
+ * @param param0 size: 스피너의 크기입니다.
+ * sm: 'w-12 h-12',
+ * md: 'w-24 h-24',
+ * lg: 'w-30 h-30',
+ * - 입력하지 않으면 md로 적용됩니다
+ * - 사용 예시) size='lg'
+ * @returns
+ */
+function LoadingSpinner({ size = 'md' }: Props) {
+  const sizeClassName = sizeMap[size];
+  console.log(sizeClassName);
+  return (
+    <div className="text-center mt-30">
+      <div role="status">
+        <svg
+          aria-hidden="true"
+          // className={`inline w-[120px] h-[120px] text-gray-200 animate-spin dark:text-gray-600 fill-blue-600`}
+          className={`inline ${sizeClassName} text-gray-200 animate-spin dark:text-gray-600 fill-blue-600`}
+          viewBox="0 0 100 101"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+            fill="currentColor"
+          />
+          <path
+            d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+            fill="currentFill"
+          />
+        </svg>
+        <span className="sr-only">Loading...</span>
+      </div>
+    </div>
+  );
+}
+
+export default LoadingSpinner;

--- a/components/atoms/UserAvartar.tsx
+++ b/components/atoms/UserAvartar.tsx
@@ -1,6 +1,6 @@
-import Image from 'next/image';
 import avatar_1 from '@/assets/images/avatartion-1.svg';
 import clsx from 'clsx';
+import Image from 'next/image';
 
 type Props = {
   imgUrl: string;

--- a/components/molecules/ButtonAuth.tsx
+++ b/components/molecules/ButtonAuth.tsx
@@ -1,18 +1,29 @@
 'use client';
 
 import userApi from '@/api/user/user.api';
-import icAlarm from '@/assets/images/ic-alarm.svg';
 import icMenu from '@/assets/images/ic-menu.svg';
-import icProfile from '@/assets/images/ic-profile.svg';
 import { useAuth } from '@/contexts/AuthContext';
+import useOutsideClick from '@/hooks/useOutsideClick';
 import { getBrowserQueryClient } from '@/libs/tanstack-query/reactQueryConfig';
+import { GetUserMe } from '@/types/dtos/user.dto';
 import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { useCallback, useRef, useState } from 'react';
 import ButtonSolid from '../atoms/ButtonSolid';
+import IconAlarm from '../atoms/IconAlarm';
+import DropdownNotification from './DropdownNotifications';
+import DropdownProfile from './DropdownProfile';
+import UserProfile from './UserProfile';
 
 function ButtonAuth() {
   const { logOut } = useAuth();
+  const [isShowProfilePopup, setIsShowProfilePopup] = useState(false);
+  const [isShowNotificationsPopup, setIsShowNotificationsPopup] =
+    useState(false);
+
+  const popupProfileRef = useRef<HTMLDivElement | null>(null);
+  const popupNotificationRef = useRef<HTMLDivElement | null>(null);
 
   const userQueryClient = getBrowserQueryClient({
     queries: {
@@ -20,7 +31,7 @@ function ButtonAuth() {
       retry: 0,
     },
   });
-  const { data: user } = useQuery({
+  const { data: user } = useQuery<GetUserMe>({
     queryKey: ['me'],
     queryFn: userApi.getUserMe,
     initialData: () => userQueryClient.getQueryData(['me']),
@@ -31,47 +42,69 @@ function ButtonAuth() {
     router.push('/auth/log-in');
   };
 
-  const handleClickLogOut = () => {
+  // 자주 사용되진 않으나 Dropdown컴포넌트에 전달되어 사용되므로
+  // useCallback을 사용해서 문제될 것은 없다고 판단하여 일단 적용해 봄(추후 자세히 분석해보자)
+  const handleClickLogOut = useCallback(() => {
+    setIsShowNotificationsPopup(false);
+    setIsShowProfilePopup(false);
     logOut?.();
     userQueryClient.removeQueries({ queryKey: ['me'] });
+  }, [logOut, userQueryClient]);
+
+  const handleClickAlarm = () => {
+    setIsShowNotificationsPopup(!isShowNotificationsPopup);
+    setIsShowProfilePopup(false);
   };
+
+  const handleClickProfile = () => {
+    setIsShowProfilePopup(!isShowProfilePopup);
+    setIsShowNotificationsPopup(false);
+  };
+
+  // 외부 영역 클릭 감지 훅 적용
+  useOutsideClick(
+    popupProfileRef,
+    () => setIsShowProfilePopup(false),
+    isShowProfilePopup
+  );
+  useOutsideClick(
+    popupNotificationRef,
+    () => setIsShowNotificationsPopup(false),
+    isShowNotificationsPopup
+  );
 
   if (user) {
     return (
-      <div className="flex items-center">
-        <Image
-          src={icAlarm}
-          alt="알림"
-          className="w-6 h-6 lg:w-9 lg:h-9 cursor-pointer"
+      <div className="flex items-center relative">
+        <IconAlarm onClick={handleClickAlarm} />
+        <UserProfile
+          onClick={handleClickProfile}
+          name={user.name}
+          profileImage={user.profileImage}
         />
-
-        <div className="flex items-center relative w-6 h-6 lg:w-9 lg:h-9 ml-6 lg:ml-8 cursor-pointer">
-          {user.profileImage ? (
-            <Image
-              src={user.profileImage}
-              alt="프로필 이미지"
-              fill
-              className="rounded-full"
-            />
-          ) : (
-            <Image
-              src={icProfile}
-              alt="빈 프로필"
-              className="w-6 h-6 lg:w-9 lg:h-9"
-            />
-          )}
-        </div>
-        <p className="hidden ml-4 lg:block text-lg font-medium text-Black-400 cursor-pointer">
-          {user.name}
-        </p>
+        {isShowProfilePopup && (
+          <DropdownProfile
+            username={user.name}
+            role={user.role}
+            isOpen={isShowProfilePopup}
+            onClose={() => setIsShowProfilePopup(false)}
+            logOut={handleClickLogOut}
+            ref={popupProfileRef}
+          />
+        )}
+        {isShowNotificationsPopup && (
+          <DropdownNotification
+            isOpen={isShowNotificationsPopup}
+            notifications={[]}
+            onClose={() => setIsShowNotificationsPopup(false)}
+            ref={popupNotificationRef}
+          />
+        )}
         <Image
           src={icMenu}
           alt="메뉴 아이콘"
           className="w-6 h-6 ml-6 cursor-pointer lg:hidden"
         />
-        <p onClick={handleClickLogOut} className="ml-4 hidden lg:inline">
-          로그아웃
-        </p>
       </div>
     );
   } else {

--- a/components/molecules/ButtonAuth.tsx
+++ b/components/molecules/ButtonAuth.tsx
@@ -24,7 +24,6 @@ function ButtonAuth() {
     queryKey: ['me'],
     queryFn: userApi.getUserMe,
     initialData: () => userQueryClient.getQueryData(['me']),
-    enabled: typeof window !== 'undefined', // CSR에서만 실행되게
   });
 
   const router = useRouter();

--- a/components/molecules/DropdownNotifications.tsx
+++ b/components/molecules/DropdownNotifications.tsx
@@ -11,6 +11,7 @@
  *   isOpen={isOpen}
  *   onClose={() => setIsOpen(false)}
  *   onMarkAsRead={(id) => console.log(`알림 ${id} 읽음 처리`)}
+ *   ref={ref} // 외부에서 감지할 때 사용
  * />
  *
  * @param {NotificationItem[]} props.notifications - 알림 목록
@@ -22,7 +23,7 @@
 'use client';
 
 import clsx from 'clsx';
-import { useEffect, useRef } from 'react';
+import { forwardRef, useRef } from 'react';
 
 interface NotificationItem {
   id: string;
@@ -38,37 +39,36 @@ interface DropdownNotificationProps {
   onMarkAsRead?: (id: string) => void;
 }
 
-function DropdownNotification({
-  notifications,
-  isOpen,
-  onClose,
-  onMarkAsRead,
-}: DropdownNotificationProps) {
-  const dropdownRef = useRef<HTMLDivElement>(null);
+// forwardRef로 변경
+const DropdownNotification = forwardRef<
+  HTMLDivElement,
+  DropdownNotificationProps
+>(({ notifications, isOpen, onClose, onMarkAsRead }, ref) => {
+  const innerRef = useRef<HTMLDivElement>(null);
 
   // 밖에 클릭했을때
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-      if (target.closest('[data-button-id="notification-button"]')) {
-        return;
-      }
+  // useEffect(() => {
+  //   const handleClickOutside = (event: MouseEvent) => {
+  //     const target = event.target as HTMLElement;
+  //     if (target.closest('[data-button-id="notification-button"]')) {
+  //       return;
+  //     }
 
-      if (dropdownRef.current && !dropdownRef.current.contains(target)) {
-        onClose();
-      }
-    };
+  //     if (innerRef.current && !innerRef.current.contains(target)) {
+  //       onClose();
+  //     }
+  //   };
 
-    if (isOpen) {
-      setTimeout(() => {
-        document.addEventListener('mousedown', handleClickOutside);
-      }, 0);
-    }
+  //   if (isOpen) {
+  //     setTimeout(() => {
+  //       document.addEventListener('mousedown', handleClickOutside);
+  //     }, 0);
+  //   }
 
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen, onClose]);
+  //   return () => {
+  //     document.removeEventListener('mousedown', handleClickOutside);
+  //   };
+  // }, [isOpen, onClose]);
 
   // 알림 클릭 처리
   const handleNotificationClick = (id: string) => {
@@ -81,23 +81,23 @@ function DropdownNotification({
 
   return (
     <div
-      ref={dropdownRef}
+      ref={ref ?? innerRef}
       className={clsx(
-        'absolute top-16 right-0 w-[312px] lg:w-[359px] bg-white rounded-xl shadow-md',
+        'absolute top-8 lg:top-13 right-10 md:right-10 lg:right-auto w-[312px] lg:w-[359px] bg-white rounded-xl shadow-md',
         'border border-GrayScale-100 overflow-hidden z-50 max-h-[314px] lg:max-h-[352px] overflow-y-auto'
       )}
     >
-      <div className='p-4 flex justify-between items-center'>
-        <h3 className='font-bold text-base lg:text-lg text-Black-400'>알림</h3>
+      <div className="p-4 flex justify-between items-center">
+        <h3 className="font-bold text-base lg:text-lg text-Black-400">알림</h3>
         <button
           onClick={onClose}
-          className='text-GrayScale-400 hover:text-Black-400 transition-colors'
-          aria-label='알림 닫기'
+          className="text-GrayScale-400 hover:text-Black-400 transition-colors"
+          aria-label="알림 닫기"
         >
           ✕
         </button>
       </div>
-      <div className='py-2'>
+      <div className="py-2">
         {notifications.length > 0 ? (
           notifications.map((notification) => (
             <div
@@ -108,7 +108,7 @@ function DropdownNotification({
               )}
               onClick={() => handleNotificationClick(notification.id)}
             >
-              <div className='flex justify-between items-start mb-2'>
+              <div className="flex justify-between items-start mb-2">
                 <p
                   className={clsx(
                     'text-Black-400 font-medium text-sm lg:text-base',
@@ -120,20 +120,22 @@ function DropdownNotification({
                   {notification.message}
                 </p>
                 {!notification.isRead && (
-                  <span className='w-2 h-2 rounded-full bg-Primay-Blue-300 flex-shrink-0 mt-1'></span>
+                  <span className="w-2 h-2 rounded-full bg-Primay-Blue-300 flex-shrink-0 mt-1"></span>
                 )}
               </div>
-              <p className='text-sm text-GrayScale-400'>{notification.time}</p>
+              <p className="text-sm text-GrayScale-400">{notification.time}</p>
             </div>
           ))
         ) : (
-          <div className='py-8 text-center text-GrayScale-400'>
+          <div className="py-8 text-center text-GrayScale-400">
             새로운 알림이 없습니다.
           </div>
         )}
       </div>
     </div>
   );
-}
+});
+
+DropdownNotification.displayName = 'DropdownNotification';
 
 export default DropdownNotification;

--- a/components/molecules/DropdownProfile.tsx
+++ b/components/molecules/DropdownProfile.tsx
@@ -11,6 +11,8 @@
  *   isOpen={isOpen}
  *   onClose={() => setIsOpen(false)}
  *   role="customer"
+ *   logOut={handleLogOut}
+ *   ref={dropdownRef}
  * />
  *
  * @param {string} props.username - 사용자 이름
@@ -23,114 +25,122 @@
 
 import clsx from 'clsx';
 import Link from 'next/link';
-import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { forwardRef } from 'react';
 import { Role } from '../../types/entities/user.entity';
 
 interface DropdownProfileProps {
   username: string;
   isOpen: boolean;
   onClose: () => void;
+  logOut: () => void;
   role: Role; // 기존 타입 정의 사용: 'customer' 또는 'worker'
 }
 
-function DropdownProfile({
-  username,
-  isOpen,
-  onClose,
-  role,
-}: DropdownProfileProps) {
-  const dropdownRef = useRef<HTMLDivElement>(null);
+const DropdownProfile = forwardRef<HTMLDivElement, DropdownProfileProps>(
+  function DropdownProfile({ username, isOpen, onClose, logOut, role }, ref) {
+    const router = useRouter();
 
-  // 외부 클릭 감지
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-      if (target.closest('[data-button-id="profile-button"]')) {
-        return;
-      }
-
-      if (dropdownRef.current && !dropdownRef.current.contains(target)) {
-        onClose();
-      }
+    const handleClickFavorite = () => {
+      router.push('/customer/favorites');
+      onClose();
     };
 
-    if (isOpen) {
-      setTimeout(() => {
-        document.addEventListener('mousedown', handleClickOutside);
-      }, 0);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
+    const handleClickReview = () => {
+      router.push('/customer/reviews/pending');
+      onClose();
     };
-  }, [isOpen, onClose]);
 
-  // 로그아웃 처리 일단 요기에 자리 만들었습니다
-  const handleLogout = () => {
-    console.log('로그아웃 처리');
-    onClose();
-  };
+    // 외부 클릭 감지용 useEffect를 사용할 수 있습니다.
+    // const dropdownRef = useRef<HTMLDivElement>(null);
+    // useEffect(() => {
+    //   const handleClickOutside = (event: MouseEvent) => {
+    //     const target = event.target as HTMLElement;
+    //     if (target.closest('[data-button-id="profile-button"]')) {
+    //       return;
+    //     }
+    //     if (dropdownRef.current && !dropdownRef.current.contains(target)) {
+    //       onClose();
+    //     }
+    //   };
+    //   if (isOpen) {
+    //     setTimeout(() => {
+    //       document.addEventListener('mousedown', handleClickOutside);
+    //     }, 0);
+    //   }
+    //   return () => {
+    //     document.removeEventListener('mousedown', handleClickOutside);
+    //   };
+    // }, [isOpen, onClose]);
 
-  if (!isOpen) return null;
+    // 로그아웃 처리
+    const handleClickLogout = () => {
+      console.log('로그아웃 처리');
+      logOut();
+    };
 
-  // 메뉴들 공통 스타일, 마진은 박스 패딩에서 조절했습니다
-  const menuItemClass =
-    'w-[140px] lg:w-[240px] h-[42px] lg:h-[54px] flex items-center px-3 lg:px-6 text-Black-400 hover:bg-Primay-Blue-50 transition-colors';
+    if (!isOpen) return null;
 
-  return (
-    // 감싸는 div에 필요시 z-index 추가해야 할수도 있음 추후?
-    <div
-      ref={dropdownRef}
-      className={clsx(
-        'absolute top-16 right-0 bg-white rounded-xl shadow-md  px-1.5 lg:px-1 pt-2.5 lg:pt-4',
-        'border border-GrayScale-100 overflow-hidden'
-      )}
-    >
-      <div className={clsx(menuItemClass)}>
-        <p className='font-bold text-base lg:text-lg text-Black-400'>
-          {username} {role === 'customer' ? '고객님' : '기사님'}
-        </p>
-      </div>
-      <div className='py-2'>
-        {role === 'customer' ? (
-          // 일반 사용자용 메뉴
-          <>
-            <Link href='/mypage/profile' className={menuItemClass}>
-              프로필 수정
-            </Link>
-            <Link href='/mypage/favorites' className={menuItemClass}>
-              찜한 기사님
-            </Link>
-            <Link href='/mypage/reviews' className={menuItemClass}>
-              이사 리뷰
-            </Link>
-          </>
-        ) : (
-          // 기사님용 메뉴 :('worker')
-          <>
-            <Link href='/worker/profile' className={menuItemClass}>
-              프로필 수정
-            </Link>
-            <Link href='/worker/mypage' className={menuItemClass}>
-              마이페이지
-            </Link>
-            <Link href='/worker/quotes' className={menuItemClass}>
-              받은 견적
-            </Link>
-          </>
+    // 메뉴들 공통 스타일, 마진은 박스 패딩에서 조절했습니다
+    const menuItemClass =
+      'cursor-pointer w-[140px] lg:w-[240px] h-[42px] lg:h-[54px] flex items-center px-3 lg:px-6 text-Black-400 hover:bg-Primay-Blue-50 transition-colors';
+
+    return (
+      // 감싸는 div에 필요시 z-index 추가해야 할 수도 있음
+      <div
+        ref={ref}
+        className={clsx(
+          'absolute top-8 lg:top-13 left-5 lg:left-14 bg-white rounded-xl shadow-md px-1.5 lg:px-1 pt-2.5 lg:pt-4',
+          'border border-GrayScale-100 overflow-hidden z-50'
         )}
-      </div>
+      >
+        <div className={clsx(menuItemClass)}>
+          <p className="font-bold text-base lg:text-lg text-Black-400">
+            {username} {role === 'customer' ? '고객님' : '기사님'}
+          </p>
+        </div>
 
-      <div className='border-t border-GrayScale-100'>
-        <button
-          onClick={handleLogout}
-          className='text-GrayScale-400 text-xs lg:text-sm font-medium w-[140px] lg:w-[240px] h-[38px] lg:h-[45px] hover:bg-Primay-Blue-50 transition-colors'
-        >
-          로그아웃
-        </button>
+        <div className="py-2">
+          {role === 'customer' ? (
+            // 고객용 메뉴
+            <>
+              <Link href="/mypage/profile" className={menuItemClass}>
+                프로필 수정
+              </Link>
+              <div className={menuItemClass} onClick={handleClickFavorite}>
+                찜한 기사님
+              </div>
+              <div className={menuItemClass} onClick={handleClickReview}>
+                이사 리뷰
+              </div>
+            </>
+          ) : (
+            // 기사님용 메뉴
+            <>
+              <Link href="/worker/profile" className={menuItemClass}>
+                프로필 수정
+              </Link>
+              <Link href="/worker/mypage" className={menuItemClass}>
+                마이페이지
+              </Link>
+              <Link href="/worker/quotes" className={menuItemClass}>
+                받은 견적
+              </Link>
+            </>
+          )}
+        </div>
+
+        <div className="border-t border-GrayScale-100">
+          <button
+            onClick={handleClickLogout}
+            className="text-GrayScale-400 text-xs lg:text-sm font-medium w-[140px] lg:w-[240px] h-[38px] lg:h-[45px] hover:bg-Primay-Blue-50 transition-colors"
+          >
+            로그아웃
+          </button>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);
 
 export default DropdownProfile;

--- a/components/molecules/UserProfile.tsx
+++ b/components/molecules/UserProfile.tsx
@@ -1,0 +1,40 @@
+import icProfile from '@/assets/images/ic-profile.svg';
+import Image from 'next/image';
+
+interface Props {
+  onClick: () => void;
+  profileImage?: string;
+  name: string;
+}
+
+function UserProfile({ onClick, profileImage, name }: Props) {
+  return (
+    <div
+      onClick={onClick}
+      className="flex items-center cursor-pointer hover:opacity-60 active:opacity-40"
+    >
+      <div className="flex items-center relative w-6 h-6 lg:w-9 lg:h-9 ml-6 lg:ml-8">
+        {profileImage ? (
+          <Image
+            src={profileImage}
+            alt="프로필 이미지"
+            fill
+            className="rounded-full"
+          />
+        ) : (
+          <Image
+            src={icProfile}
+            alt="빈 프로필"
+            className="w-6 h-6 lg:w-9 lg:h-9"
+          />
+        )}
+      </div>
+
+      <p className="hidden ml-4 lg:block text-lg font-medium text-Black-400">
+        {name}
+      </p>
+    </div>
+  );
+}
+
+export default UserProfile;

--- a/components/organisms/DriverCardInLiked.tsx
+++ b/components/organisms/DriverCardInLiked.tsx
@@ -3,7 +3,8 @@ import UserAvartar from '../atoms/UserAvartar';
 import LikeCount from '../molecules/LikeCount';
 import RatingSummary from '../molecules/RatingSummary';
 
-type Props = {
+export type DriverCardInLikedProps = {
+  id: string;
   profileImage: string;
   nickname: string;
   experience: string;
@@ -46,7 +47,7 @@ function DriverCardInLiked({
   isFavorite,
   favoritesCount,
   services,
-}: Props) {
+}: DriverCardInLikedProps) {
   return (
     <div className="flex flex-col justify-between gap-2 bg-GrayScale-50 border-Line-100 border-[0.5px] rounded-2xl w-[327px] h-[150px] md:w-[600px] lg:w-[688px] lg:h-[202px] px-3.5 py-4">
       <div className="flex gap-2.5">

--- a/components/organisms/ListFavoriteWorker.tsx
+++ b/components/organisms/ListFavoriteWorker.tsx
@@ -2,6 +2,7 @@
 
 import favoriteApi from '@/api/favorite/favorite.api';
 import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import LoadingSpinner from '../atoms/LoadingSpinner';
 import DriverCardInLiked, { DriverCardInLikedProps } from './DriverCardInLiked';
 
@@ -15,12 +16,17 @@ function ListFavoriteWorker() {
     queryFn: favoriteApi.getFavoriteWorkers,
   });
 
-  const handleClickCard = (id: string) => {
-    console.log(id, '기사님 상세로 이동');
+  const router = useRouter();
+
+  const handleClickCard = (workerId: string) => {
+    console.log(workerId, '기사님 상세로 이동');
+    router.push(`/worker/${workerId}`);
   };
 
   if (isLoading) return <LoadingSpinner />;
   if (isError || !favorites) return <div>오류 발생!</div>;
+  if (favorites && favorites.length === 0)
+    return <div>찜한 기사님이 없습니다</div>;
   console.log(favorites);
   return (
     <div className="md:w-[600px] lg:w-[1400px] flex flex-wrap gap-x-6 gap-y-12">

--- a/components/organisms/ListFavoriteWorker.tsx
+++ b/components/organisms/ListFavoriteWorker.tsx
@@ -15,6 +15,10 @@ function ListFavoriteWorker() {
     queryFn: favoriteApi.getFavoriteWorkers,
   });
 
+  const handleClickCard = (id: string) => {
+    console.log(id, '기사님 상세로 이동');
+  };
+
   if (isLoading) return <LoadingSpinner />;
   if (isError || !favorites) return <div>오류 발생!</div>;
   console.log(favorites);
@@ -23,7 +27,11 @@ function ListFavoriteWorker() {
       {favorites.list.map((worker: DriverCardInLikedProps) => {
         console.log(worker.profileImage);
         return (
-          <div key={worker.id} className="shrink-0">
+          <div
+            key={worker.id}
+            className="shrink-0 cursor-pointer hover:opacity-60 active:opacity-80"
+            onClick={() => handleClickCard(worker.id)}
+          >
             <DriverCardInLiked {...worker} />
           </div>
         );

--- a/components/organisms/ListFavoriteWorker.tsx
+++ b/components/organisms/ListFavoriteWorker.tsx
@@ -1,5 +1,35 @@
+'use client';
+
+import favoriteApi from '@/api/favorite/favorite.api';
+import { useQuery } from '@tanstack/react-query';
+import LoadingSpinner from '../atoms/LoadingSpinner';
+import DriverCardInLiked, { DriverCardInLikedProps } from './DriverCardInLiked';
+
 function ListFavoriteWorker() {
-  return <div className="w-[1400px]">ListFavoriteWorker</div>;
+  const {
+    data: favorites,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['favorites'],
+    queryFn: favoriteApi.getFavoriteWorkers,
+  });
+
+  if (isLoading) return <LoadingSpinner />;
+  if (isError || !favorites) return <div>오류 발생!</div>;
+  console.log(favorites);
+  return (
+    <div className="md:w-[600px] lg:w-[1400px] flex flex-wrap gap-x-6 gap-y-12">
+      {favorites.list.map((worker: DriverCardInLikedProps) => {
+        console.log(worker.profileImage);
+        return (
+          <div key={worker.id} className="shrink-0">
+            <DriverCardInLiked {...worker} />
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export default ListFavoriteWorker;

--- a/hooks/useOutsideClick.tsx
+++ b/hooks/useOutsideClick.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+function useOutsideClick(
+  ref: React.RefObject<HTMLElement | null>,
+  onClose: () => void,
+  isOpen: boolean
+) {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      if (ref.current && !ref.current.contains(target)) {
+        // 외부 클릭으로 팝업을 닫는 로직
+        if (isOpen) {
+          // setTimeout을 사용하여 상태 변경을 지연시켜 바로 반영되지 않게 함
+          // 적용하지 않으면 같은 버튼을 눌렀을 때 상태 토글이 제대로 작동하지 않음
+          setTimeout(() => {
+            onClose();
+          }, 100); // 100ms 정도의 지연
+        }
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, ref, onClose]);
+}
+
+export default useOutsideClick;

--- a/libs/tanstack-query/index.tsx
+++ b/libs/tanstack-query/index.tsx
@@ -6,6 +6,8 @@ import {
   getBrowserQueryClient,
 } from './reactQueryConfig';
 
+// 간단한 구조의 프로젝트에서는 provider에서만 구분하여 생성하고 내려줘도 되지만
+// 규모가 커질 경우 지금처럼 별도 함수로 분리하여 관리하는 것이 좋음
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = isServer
     ? createServerQueryClient()

--- a/types/dtos/user.dto.ts
+++ b/types/dtos/user.dto.ts
@@ -14,4 +14,10 @@ export type UpdateUserInfoDto = Pick<
 // (고객/기사님 공통) '기본정보 수정' 페이지에 사용합니다.
 export type UserInfoEditDto = Pick<User, 'name' | 'email' | 'phoneNumber'>;
 
+// 로그인 사용자 정보
+export type GetUserMe = Pick<
+  User,
+  'name' | 'hasProfile' | 'role' | 'hasRequest' | 'profileImage'
+>;
+
 /* ------------------- 백엔드 API 비교 완료 --------------------- */


### PR DESCRIPTION
### queryClient 생성 방식 변경
- 기존: providers에서 서버와 클라이언트(브라우저) 분기
- 변경: createServerQueryClient와 getBrowserQueryClient 함수 별도 분리   
  - 각 함수에 기본 옵션값 설정(파라미터로 커스텀 옵션 설정 가능) 
  - 현재 프로젝트 구조에서는 providers에서만 분기해도 충분하나 복잡한 프로젝트에서는 분리가 필요(학습을 위해 분리 구조 구현해 봄)
### '찜한 기사님 목록'페이지 구현
- tanstack query prefetch를 이용한 SSR 구현 
- LoadingSpinner구현
![무빙  로딩 스피너](https://github.com/user-attachments/assets/f84dc30d-1b54-4ac6-93da-2e4acc19d5d1)
<br>

### Gnb에 알림, 프로필 팝업 메뉴 구현

- 외부 영역 클릭 감지 훅 적용(useOutsideClick) 
- 기존 DropdownProfile, DropdownNotification코드 일부 수정   
  - CSS수정, 외부 영역 클릭 감지 코드 삭제(주석)   
  - Link태그를 router로 수정 등
 
![무빙  Gnb 팝업 구현-2](https://github.com/user-attachments/assets/3a3a0305-ae65-40bb-b953-416c85833778)
