### PR TITLE
[조형민] FormLogIn 파일명 import 오류 수정, FavoriteWorkersPage의 prefetch 수정 

### DIFF
--- a/app/(providers)/(root)/customer/favorites/page.tsx
+++ b/app/(providers)/(root)/customer/favorites/page.tsx
@@ -1,5 +1,4 @@
 import favoriteApi from '@/api/favorite/favorite.api';
-import userApi from '@/api/user/user.api';
 import ListFavoriteWorker from '@/components/organisms/ListFavoriteWorker';
 import { handleSSRPrefetch } from '@/libs/tanstack-query/ssrPrefetchHelper';
 import { getAccessTokenFromRefresh } from '@/utils/jwtUtils';
@@ -20,10 +19,11 @@ async function FavoriteWorkersPage() {
   }
 
   const { dehydratedState } = await handleSSRPrefetch([
-    {
-      queryKey: ['me'],
-      queryFn: () => userApi.getUserMeServer(accessToken),
-    },
+    // layout(ProvidersLayout)에서 user를 setQueryData로 캐싱하고 있으므로 현재 구조에선 불필요
+    // {
+    //   queryKey: ['me'],
+    //   queryFn: () => userApi.getUserMeServer(accessToken),
+    // },
     {
       queryKey: ['favorites'],
       queryFn: () => favoriteApi.getFavoriteWorkersServer(accessToken),

--- a/components/templates/TemplateLogIn.tsx
+++ b/components/templates/TemplateLogIn.tsx
@@ -3,7 +3,7 @@
 import { Role } from '@/types/entities/user.entity';
 import FooterAuthPage from '../molecules/FooterAuthPage';
 import HeaderAuthPage from '../molecules/HeaderAuthPage';
-import FormLogIn from '../organisms/FormLogin';
+import FormLogIn from '../organisms/FormLogIn';
 
 function TemplateLogIn({ userType }: { userType: Role }) {
   return (


### PR DESCRIPTION
- FormLogIn 파일명 import 오류 수정
- FavoriteWorkersPage의 prefetch 수정 
  - ['me'] 쿼리 삭제
  - 현재 ProvidersLayout에서 setQueryData로 캐싱하고 있으므로 불필요