### PR TITLE
[조형민] 소셜 로그인 구현

### DIFF
--- a/api/auth/auth.api.ts
+++ b/api/auth/auth.api.ts
@@ -1,4 +1,5 @@
 import { LogInDto, SignUpDto } from '@/types/dtos/auth.dto';
+import { Role } from '@/types/entities/user.entity';
 import { client, errorHandler } from '../client';
 
 // 회원가입
@@ -40,13 +41,12 @@ const refreshToken = async () => {
   }
 };
 
-// const MOCK_REDIRECT_URL = 'http://localhost:3000/auth/callback?code=fakeCode';
-
 // 소셜 로그인
-const handleOAuthLogin = (provider: 'google' | 'kakao' | 'naver') => {
-  console.log(provider); // never used 에러 방지용
-  // window.location.href = MOCK_REDIRECT_URL;
-  window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/${provider}`;
+const handleOAuthLogin = (
+  role: Role | null,
+  provider: 'google' | 'kakao' | 'naver'
+) => {
+  window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/${provider}?role=${role}`;
 };
 
 const authApi = {

--- a/api/auth/auth.api.ts
+++ b/api/auth/auth.api.ts
@@ -1,16 +1,16 @@
-import { LogInDto, SignUpDto } from "@/types/dtos/auth.dto";
-import { client, errorHandler } from "../client";
+import { LogInDto, SignUpDto } from '@/types/dtos/auth.dto';
+import { client, errorHandler } from '../client';
 
 // 회원가입
 const singUp = async (dto: SignUpDto) => {
-  const url = "/auth/sign-up";
+  const url = '/auth/sign-up';
   const response = await client.post(url, dto);
   return response.data;
 };
 
 // 로그인
 const logIn = async (dto: LogInDto) => {
-  const url = "/auth/log-in";
+  const url = '/auth/log-in';
   const response = await client.post(url, dto);
 
   return response.data;
@@ -19,7 +19,7 @@ const logIn = async (dto: LogInDto) => {
 // 로그아웃 (refreshToken 무효화)
 const logOut = async () => {
   try {
-    const url = "/auth/log-out";
+    const url = '/auth/log-out';
     await client.delete(url); // refreshToken은 쿠키로 자동 전송됨
   } catch (error) {
     errorHandler(error);
@@ -29,10 +29,10 @@ const logOut = async () => {
 // 토큰 재발급
 const refreshToken = async () => {
   try {
-    const url = "/auth/refresh-token";
+    const url = '/auth/refresh-token';
     const response = await client.post(url, {}, { withCredentials: true }); // refreshToken은 쿠키로 자동 전송됨
     const { accessToken } = response.data;
-    console.log("refreshToken api accessToken", accessToken);
+    console.log('refreshToken api accessToken', accessToken);
 
     return response.data;
   } catch (error) {
@@ -40,11 +40,21 @@ const refreshToken = async () => {
   }
 };
 
+// const MOCK_REDIRECT_URL = 'http://localhost:3000/auth/callback?code=fakeCode';
+
+// 소셜 로그인
+const handleOAuthLogin = (provider: 'google' | 'kakao' | 'naver') => {
+  console.log(provider); // never used 에러 방지용
+  // window.location.href = MOCK_REDIRECT_URL;
+  window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/auth/${provider}`;
+};
+
 const authApi = {
   singUp,
   logIn,
   logOut,
   refreshToken,
+  handleOAuthLogin,
 };
 
 export default authApi;

--- a/api/user/user.api.ts
+++ b/api/user/user.api.ts
@@ -3,10 +3,10 @@ import { client, errorHandler } from '../client';
 
 // 내 정보 조회
 const getUserMe = async () => {
-  if (typeof window === 'undefined') {
-    // SSR에서는 axios 말고, getUserMeServer를 사용하도록 유도
-    throw new Error('getUserMe는 클라이언트에서만 사용 가능합니다.');
-  }
+  // if (typeof window === 'undefined') {
+  //   // SSR에서는 axios 말고, getUserMeServer를 사용하도록 유도
+  //   throw new Error('getUserMe는 클라이언트에서만 사용 가능합니다.');
+  // }
   try {
     const url = '/user/me';
     const response = await client.get(url);

--- a/app/(providers)/(root)/auth/callback/page.tsx
+++ b/app/(providers)/(root)/auth/callback/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import LoadingSpinner from '@/components/atoms/LoadingSpinner';
+import ROUTES from '@/constants/routes';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect } from 'react';
+
+export default function OAuthCallbackPage() {
+  console.log('callback login 실행');
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { logIn } = useAuth();
+
+  useEffect(() => {
+    const doLogin = async () => {
+      const error = searchParams.get('error');
+      if (error) {
+        alert('소셜 로그인에 실패했습니다.');
+        router.replace(ROUTES.LOG_IN);
+        return;
+      }
+
+      if (logIn) {
+        console.log('callback login 실행');
+        await logIn(); // me 쿼리 실행/세팅
+        router.replace(ROUTES.HOME); // 또는 이전 페이지로 리다이렉트
+      }
+    };
+    doLogin();
+  }, [logIn, searchParams, router]);
+
+  return (
+    <div className="flex flex-col items-center justify-center">
+      <LoadingSpinner size="md" />
+      <p className="text-3xl mt-10">소셜 로그인 중입니다...</p>
+    </div>
+  );
+}

--- a/app/(providers)/(root)/auth/callback/page.tsx
+++ b/app/(providers)/(root)/auth/callback/page.tsx
@@ -1,23 +1,25 @@
 'use client';
 
 import LoadingSpinner from '@/components/atoms/LoadingSpinner';
+import Error from '@/components/molecules/Error';
 import ROUTES from '@/constants/routes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function OAuthCallbackPage() {
-  console.log('callback login 실행');
   const router = useRouter();
   const searchParams = useSearchParams();
   const { logIn } = useAuth();
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
     const doLogin = async () => {
+      // 에러가 있을 경우 백엔드에서 url 쿼리 스트링으로 error를 전달
       const error = searchParams.get('error');
       if (error) {
-        alert('소셜 로그인에 실패했습니다.');
-        router.replace(ROUTES.LOG_IN);
+        // 에러 메시지 설정 후 로그인 시도 중단
+        setErrorMessage(error);
         return;
       }
 
@@ -30,6 +32,17 @@ export default function OAuthCallbackPage() {
     doLogin();
   }, [logIn, searchParams, router]);
 
+  // 에러 메시지가 있는 경우: 메시지 + 로그인 페이지 이동 버튼 표시
+  if (errorMessage) {
+    return (
+      <Error
+        message={errorMessage}
+        onRetry={() => router.push(ROUTES.LOG_IN)}
+      />
+    );
+  }
+
+  // 에러 메시지가 없는 경우: 소셜 로그인 로딩 화면
   return (
     <div className="flex flex-col items-center justify-center">
       <LoadingSpinner size="md" />

--- a/app/(providers)/(root)/auth/callback/page.tsx
+++ b/app/(providers)/(root)/auth/callback/page.tsx
@@ -4,6 +4,7 @@ import LoadingSpinner from '@/components/atoms/LoadingSpinner';
 import Error from '@/components/molecules/Error';
 import ROUTES from '@/constants/routes';
 import { useAuth } from '@/contexts/AuthContext';
+import { getErrorMessageFromQuery } from '@/utils/getErrorMessageFromQuery';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -15,24 +16,25 @@ export default function OAuthCallbackPage() {
 
   useEffect(() => {
     const doLogin = async () => {
-      // 에러가 있을 경우 백엔드에서 url 쿼리 스트링으로 error를 전달
-      const error = searchParams.get('error');
-      if (error) {
-        // 에러 메시지 설정 후 로그인 시도 중단
-        setErrorMessage(error);
+      const errorCode = searchParams.get('errorCode');
+      // 에러 발생 시 url 쿼리 스트링으로 errorCode, provider, role을 전달받고
+      // 그것을 이용하여 에러 메시지를 생성
+      if (errorCode) {
+        const message = getErrorMessageFromQuery(searchParams);
+        setErrorMessage(message);
         return;
       }
 
+      // 에러가 없으면 로그인
       if (logIn) {
-        console.log('callback login 실행');
         await logIn(); // me 쿼리 실행/세팅
-        router.replace(ROUTES.HOME); // 또는 이전 페이지로 리다이렉트
+        router.replace(ROUTES.HOME); // 또는 이전 페이지로 리다이렉트 등 가능
       }
     };
     doLogin();
   }, [logIn, searchParams, router]);
 
-  // 에러 메시지가 있는 경우: 메시지 + 로그인 페이지 이동 버튼 표시
+  // 에러가 있는 경우: 메시지 + 로그인 페이지 이동 버튼 표시
   if (errorMessage) {
     return (
       <Error
@@ -42,7 +44,7 @@ export default function OAuthCallbackPage() {
     );
   }
 
-  // 에러 메시지가 없는 경우: 소셜 로그인 로딩 화면
+  // 에러가 없는 경우: 소셜 로그인 로딩 화면
   return (
     <div className="flex flex-col items-center justify-center">
       <LoadingSpinner size="md" />

--- a/app/(providers)/(root)/auth/log-in/page.tsx
+++ b/app/(providers)/(root)/auth/log-in/page.tsx
@@ -7,19 +7,19 @@ import { useSearchParams } from 'next/navigation';
 
 function LogInPage() {
   const params = useSearchParams();
-  const paramString = params.get('userType');
-  let userType: Role;
+  const paramString = params.get('role');
+  let role: Role;
   if (!paramString) {
-    userType = 'customer';
+    role = 'customer';
   } else if (paramString === 'customer') {
-    userType = paramString;
+    role = paramString;
   } else {
-    userType = 'worker';
+    role = 'worker';
   }
 
   return (
     <PageContainer>
-      <TemplateLogIn userType={userType} />
+      <TemplateLogIn role={role} />
     </PageContainer>
   );
 }

--- a/app/(providers)/(root)/auth/sign-up/page.tsx
+++ b/app/(providers)/(root)/auth/sign-up/page.tsx
@@ -7,19 +7,19 @@ import { useSearchParams } from 'next/navigation';
 
 function SignUpPage() {
   const params = useSearchParams();
-  const paramString = params.get('userType');
-  let userType: Role;
+  const paramString = params.get('role');
+  let role: Role;
   if (!paramString) {
-    userType = 'customer';
+    role = 'customer';
   } else if (paramString === 'customer') {
-    userType = paramString;
+    role = paramString;
   } else {
-    userType = 'worker';
+    role = 'worker';
   }
 
   return (
     <PageContainer>
-      <TemplateSignUp userType={userType} />
+      <TemplateSignUp role={role} />
     </PageContainer>
   );
 }

--- a/app/(providers)/(root)/error.tsx
+++ b/app/(providers)/(root)/error.tsx
@@ -1,24 +1,13 @@
 'use client';
 
-export default function Error({
+import Error from '@/components/molecules/Error';
+
+export default function GlobalError({
   error,
   reset,
 }: {
   error: Error;
   reset: () => void;
 }) {
-  return (
-    <div className="grow flex items-center justify-center px-4 py-12">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold mb-4">에러가 발생했습니다 😢</h1>
-        <p className="text-sm text-GrayScale-500 mb-6">{error.message}</p>
-        <button
-          onClick={() => reset()}
-          className="px-4 py-2 bg-Primay-Blue-300 text-white rounded-lg cursor-pointer hover:opacity-70 active:opacity-80"
-        >
-          다시 시도하기
-        </button>
-      </div>
-    </div>
-  );
+  return <Error message={error.message} onRetry={reset} />;
 }

--- a/components/atoms/TextArea.tsx
+++ b/components/atoms/TextArea.tsx
@@ -22,7 +22,7 @@ function TextArea({
   ...props
 }: Props) {
   const defaultClassName = clsx(
-    'w-[327px] lg:w-full lg:text-xl h-40 px-[14px] py-4 rounded-2xl outline-Primary-blue-300 border border-solid border-Line-200 placeholder-GrayScale-400'
+    'resize-none w-[327px] lg:w-full lg:text-xl h-40 px-[14px] py-4 rounded-2xl outline-Primary-blue-300 border border-solid border-Line-200 placeholder-GrayScale-400'
   );
   const errorClassName = clsx({
     'outline-Secondary-Red-200 mb-2 border-solid border-2 border-Secondary-Red-200':

--- a/components/molecules/AuthSocialLogIn.tsx
+++ b/components/molecules/AuthSocialLogIn.tsx
@@ -1,3 +1,4 @@
+import authApi from '@/api/auth/auth.api';
 import icSocialGoogle from '@/assets/images/ic-social-google.svg';
 import icSocialKakao from '@/assets/images/ic-social-kakao.svg';
 import icSocialNaver from '@/assets/images/ic-social-naver.svg';
@@ -12,9 +13,24 @@ function AuthSocialLogIn() {
     <div className="flex flex-col items-center gap-6 lg:gap-8 mt-12 lg:mt-18 text-xs lg:text-xl text-Black-200">
       <p>SNS 계정으로 간편하게 시작하기</p>
       <div className="flex gap-8">
-        <Image src={icSocialGoogle} alt="구글" />
-        <Image src={icSocialKakao} alt="카카오" />
-        <Image src={icSocialNaver} alt="네이버" />
+        <button
+          onClick={() => authApi.handleOAuthLogin('google')}
+          className="cursor-pointer hover:opacity-70"
+        >
+          <Image src={icSocialGoogle} alt="구글" />
+        </button>
+        <button
+          onClick={() => authApi.handleOAuthLogin('kakao')}
+          className="cursor-pointer hover:opacity-70"
+        >
+          <Image src={icSocialKakao} alt="카카오" />
+        </button>
+        <button
+          onClick={() => authApi.handleOAuthLogin('naver')}
+          className="cursor-pointer hover:opacity-70"
+        >
+          <Image src={icSocialNaver} alt="네이버" />
+        </button>
       </div>
     </div>
   );

--- a/components/molecules/AuthSocialLogIn.tsx
+++ b/components/molecules/AuthSocialLogIn.tsx
@@ -2,31 +2,32 @@ import authApi from '@/api/auth/auth.api';
 import icSocialGoogle from '@/assets/images/ic-social-google.svg';
 import icSocialKakao from '@/assets/images/ic-social-kakao.svg';
 import icSocialNaver from '@/assets/images/ic-social-naver.svg';
+import { Role } from '@/types/entities/user.entity';
 import Image from 'next/image';
 
 /**
  * 로그인/회원가입 페이지의 '소셜 로그인' 위젯
  * @returns
  */
-function AuthSocialLogIn() {
+function AuthSocialLogIn({ role }: { role: Role | null }) {
   return (
     <div className="flex flex-col items-center gap-6 lg:gap-8 mt-12 lg:mt-18 text-xs lg:text-xl text-Black-200">
       <p>SNS 계정으로 간편하게 시작하기</p>
       <div className="flex gap-8">
         <button
-          onClick={() => authApi.handleOAuthLogin('google')}
+          onClick={() => authApi.handleOAuthLogin(role, 'google')}
           className="cursor-pointer hover:opacity-70"
         >
           <Image src={icSocialGoogle} alt="구글" />
         </button>
         <button
-          onClick={() => authApi.handleOAuthLogin('kakao')}
+          onClick={() => authApi.handleOAuthLogin(role, 'kakao')}
           className="cursor-pointer hover:opacity-70"
         >
           <Image src={icSocialKakao} alt="카카오" />
         </button>
         <button
-          onClick={() => authApi.handleOAuthLogin('naver')}
+          onClick={() => authApi.handleOAuthLogin(role, 'naver')}
           className="cursor-pointer hover:opacity-70"
         >
           <Image src={icSocialNaver} alt="네이버" />

--- a/components/molecules/Error.tsx
+++ b/components/molecules/Error.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+type ErrorProps = {
+  message?: string;
+  onRetry?: () => void;
+};
+
+/**
+ * 에러를 표시하는 UI컴포넌트입니다.
+ * @param param0 message: 에러 메시지
+ * @param param0 onRetry: 버튼 클릭 시 이동 액션
+ * @returns
+ */
+export default function Error({ message, onRetry }: ErrorProps) {
+  console.log(message);
+  return (
+    <div className="grow flex items-center justify-center px-4 py-12">
+      <div className="text-center">
+        <h1 className="text-2xl font-bold mb-4">에러가 발생했습니다 😢</h1>
+        <p
+          className="text-sm text-GrayScale-500 mb-6"
+          style={{ whiteSpace: 'pre-line' }} // 줄바꿈 스타일 추가
+        >
+          {message || '문제가 발생했습니다. 다시 시도해주세요.'}
+        </p>
+        {onRetry && (
+          <button
+            onClick={onRetry}
+            className="px-4 py-2 bg-Primay-Blue-300 text-white rounded-lg cursor-pointer hover:opacity-70 active:opacity-80"
+          >
+            다시 시도하기
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/molecules/Error.tsx
+++ b/components/molecules/Error.tsx
@@ -16,9 +16,11 @@ export default function Error({ message, onRetry }: ErrorProps) {
   return (
     <div className="grow flex items-center justify-center px-4 py-12">
       <div className="text-center">
-        <h1 className="text-2xl font-bold mb-4">에러가 발생했습니다 😢</h1>
+        <h1 className="text-2xl lg:text-3xl font-bold mb-4">
+          에러가 발생했습니다 😢
+        </h1>
         <p
-          className="text-sm text-GrayScale-500 mb-6"
+          className="text-sm lg:text-lg text-GrayScale-500 mb-6"
           style={{ whiteSpace: 'pre-line' }} // 줄바꿈 스타일 추가
         >
           {message || '문제가 발생했습니다. 다시 시도해주세요.'}

--- a/components/molecules/FooterAuthPage.tsx
+++ b/components/molecules/FooterAuthPage.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import AuthSocialLogIn from './AuthSocialLogIn';
 
 interface Props {
-  userType: Role | null;
+  role: Role | null;
   isSignUpPage: boolean;
 }
 
@@ -13,7 +13,7 @@ interface Props {
  * @param param0
  * @returns
  */
-function FooterAuthPage({ isSignUpPage, userType }: Props) {
+function FooterAuthPage({ isSignUpPage, role }: Props) {
   const text1: string = isSignUpPage
     ? '이미 무빙 회원이신가요?'
     : '아직 무빙 회원이 아니신가요?';
@@ -21,7 +21,7 @@ function FooterAuthPage({ isSignUpPage, userType }: Props) {
 
   const pageLink: string = isSignUpPage ? ROUTES.LOG_IN : ROUTES.SIGN_UP;
   const linkQuery: string =
-    userType === 'customer' ? '?userType=customer' : '?userType=worker';
+    role === 'customer' ? '?role=customer' : '?role=worker';
 
   return (
     <div>

--- a/components/molecules/FooterAuthPage.tsx
+++ b/components/molecules/FooterAuthPage.tsx
@@ -31,7 +31,7 @@ function FooterAuthPage({ isSignUpPage, role }: Props) {
           <Link href={`${pageLink}${linkQuery}`}>{text2}</Link>
         </p>
       </div>
-      <AuthSocialLogIn />
+      <AuthSocialLogIn role={role} />
     </div>
   );
 }

--- a/components/molecules/HeaderAuthPage.tsx
+++ b/components/molecules/HeaderAuthPage.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import LogoText from '../atoms/LogoText';
 
 interface Props {
-  userType: Role | null;
+  role: Role | null;
   isSignUpPage: boolean;
 }
 
@@ -15,15 +15,15 @@ interface Props {
  * @param param0
  * @returns
  */
-function HeaderAuthPage({ isSignUpPage, userType }: Props) {
+function HeaderAuthPage({ isSignUpPage, role }: Props) {
   const text1: string =
-    userType === 'customer' ? '기사님이신가요?' : '일반 유저라면?';
+    role === 'customer' ? '기사님이신가요?' : '일반 유저라면?';
   const text2: string =
-    userType === 'customer' ? '기사님 전용 페이지' : '일반 유저 전용 페이지';
+    role === 'customer' ? '기사님 전용 페이지' : '일반 유저 전용 페이지';
 
   const pageLink: string = isSignUpPage ? ROUTES.SIGN_UP : ROUTES.LOG_IN;
   const linkQuery: string =
-    userType === 'customer' ? '?userType=worker' : '?userType=customer';
+    role === 'customer' ? '?role=worker' : '?role=customer';
 
   return (
     <div className="flex flex-col items-center mb-10 lg:mb-18">

--- a/components/organisms/FormLogIn.tsx
+++ b/components/organisms/FormLogIn.tsx
@@ -17,7 +17,7 @@ export type FormLogInInput = {
   password: string;
 };
 
-function FormLogIn({ userType }: { userType: Role }) {
+function FormLogIn({ role }: { role: Role }) {
   const { control, handleSubmit, formState, setError } =
     useForm<FormLogInInput>({
       defaultValues: { email: '', password: '' },
@@ -47,7 +47,7 @@ function FormLogIn({ userType }: { userType: Role }) {
 
   const handleClickLogIn = (inputData: FormLogInInput) => {
     setIsProcessing(true);
-    logIn({ ...inputData, role: userType });
+    logIn({ ...inputData, role });
   };
 
   return (

--- a/components/organisms/FormSignUp.tsx
+++ b/components/organisms/FormSignUp.tsx
@@ -21,7 +21,7 @@ export type FormSignUpInput = {
   passwordConfirm: string;
 };
 
-function FormSignUp({ userType }: { userType: Role }) {
+function FormSignUp({ role }: { role: Role }) {
   const { control, handleSubmit, formState, setError } =
     useForm<FormSignUpInput>({
       defaultValues: {
@@ -46,7 +46,7 @@ function FormSignUp({ userType }: { userType: Role }) {
 
   const handleClickSignUp = (inputData: FormSignUpInput) => {
     setIsProcessing(true);
-    signUp({ ...inputData, role: userType });
+    signUp({ ...inputData, role });
   };
 
   return (

--- a/components/templates/TemplateLogIn.tsx
+++ b/components/templates/TemplateLogIn.tsx
@@ -5,13 +5,13 @@ import FooterAuthPage from '../molecules/FooterAuthPage';
 import HeaderAuthPage from '../molecules/HeaderAuthPage';
 import FormLogIn from '../organisms/FormLogIn';
 
-function TemplateLogIn({ userType }: { userType: Role }) {
+function TemplateLogIn({ role }: { role: Role }) {
   return (
     <div className="w-full flex flex-col justify-center items-center mt-[42px] mb-20">
       <div className="w-full flex flex-col justify-center">
-        <HeaderAuthPage isSignUpPage={false} userType={userType} />
-        <FormLogIn userType={userType} />
-        <FooterAuthPage isSignUpPage={false} userType={userType} />
+        <HeaderAuthPage isSignUpPage={false} role={role} />
+        <FormLogIn role={role} />
+        <FooterAuthPage isSignUpPage={false} role={role} />
       </div>
     </div>
   );

--- a/components/templates/TemplateSignUp.tsx
+++ b/components/templates/TemplateSignUp.tsx
@@ -5,13 +5,13 @@ import FooterAuthPage from '../molecules/FooterAuthPage';
 import HeaderAuthPage from '../molecules/HeaderAuthPage';
 import FormSignUp from '../organisms/FormSignUp';
 
-function TemplateSignUp({ userType }: { userType: Role }) {
+function TemplateSignUp({ role }: { role: Role }) {
   return (
     <div className="w-full flex flex-col justify-center items-center mt-[42px] mb-20">
       <div className="w-full flex flex-col justify-center">
-        <HeaderAuthPage isSignUpPage={true} userType={userType} />
-        <FormSignUp userType={userType} />
-        <FooterAuthPage isSignUpPage={true} userType={userType} />
+        <HeaderAuthPage isSignUpPage={true} role={role} />
+        <FormSignUp role={role} />
+        <FooterAuthPage isSignUpPage={true} role={role} />
       </div>
     </div>
   );

--- a/constants/routes.ts
+++ b/constants/routes.ts
@@ -3,6 +3,7 @@ const ROUTES = {
   LOG_IN: '/auth/log-in', // 로그인
   SIGN_UP: '/auth/sign-up', // 회원가입
   FIND_WORKER: '/find-worker', // 기사님 찾기
+  OAUTH_CALLBACK: '/auth/callback', // 소셜 로그인 콜백 페이지
   CUSTOMER: {
     ROOT: '/customer', // 견적 요청
     ESTIMATES: {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -2,9 +2,10 @@
 
 import authApi from '@/api/auth/auth.api';
 import userApi from '@/api/user/user.api';
-import { getBrowserQueryClient } from '@/libs/tanstack-query/reactQueryConfig';
+import ROUTES from '@/constants/routes';
 import { GetUserMe } from '@/types/dtos/user.dto';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 import {
   createContext,
   ReactNode,
@@ -16,16 +17,16 @@ import {
 interface AuthContextValue {
   isLoggedIn?: boolean;
   isAuthInitialized?: boolean;
-  logIn?: () => void;
-  logOut?: () => void;
+  logIn?: () => Promise<void>;
+  logOut?: () => Promise<void>;
   user?: GetUserMe;
 }
 
 const AuthContext = createContext<AuthContextValue>({
   isLoggedIn: false,
   isAuthInitialized: false,
-  logIn: () => {},
-  logOut: () => {},
+  logIn: async () => {},
+  logOut: async () => {},
 });
 
 export const useAuth = () => useContext(AuthContext);
@@ -41,26 +42,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isAuthInitialized, setIsAuthInitialized] = useState(false);
 
-  // const router = useRouter();
+  const queryClient = useQueryClient();
+  const router = useRouter();
 
-  const userQueryClient = getBrowserQueryClient({
-    queries: {
-      staleTime: Infinity, // 사용자가 로그아웃 후 재로그인하거나 정보를 변경할 때에만 갱신,
-      retry: 0,
-    },
-  });
-
-  // accessToken 존재 여부 확인 후 isAuthInitialized 설정
   useEffect(() => {
-    // const accessToken =
-    //   typeof window !== 'undefined'
-    //     ? localStorage.getItem('accessToken')
-    //     : null;
-
-    // if (!accessToken) {
-    //   setIsLoggedIn(false);
-    // }
-
     setIsAuthInitialized(true); // accessToken 여부와 상관없이 초기화는 완료
   }, []);
 
@@ -72,30 +57,29 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     enabled: isAuthInitialized,
     retry: 0,
   });
+  useEffect(() => {
+    console.log('user:', user);
+  }, [user]);
 
   useEffect(() => {
-    // if (user) {
-    //   setIsLoggedIn(true);
-    // } else {
-    //   setIsLoggedIn(false);
-    // }
     setIsLoggedIn(!!user);
   }, [user]);
 
   const logIn = async () => {
+    console.log('login 시작');
     setIsLoggedIn(true);
     setIsAuthInitialized(true);
 
     // 로그인 후 accessToken이 생기므로 쿼리 재실행
-    await userQueryClient.invalidateQueries({ queryKey: ['me'] });
+    await queryClient.invalidateQueries({ queryKey: ['me'] });
   };
 
   const logOut = async () => {
     await authApi.logOut();
-    // logoutHelper(() => router.replace('/'));
+    router.replace(ROUTES.HOME);
     setIsLoggedIn(false);
     setIsAuthInitialized(true); // 로그아웃도 초기화 완료로 처리
-    await userQueryClient.invalidateQueries({ queryKey: ['me'] });
+    await queryClient.invalidateQueries({ queryKey: ['me'] });
   };
 
   const value: AuthContextValue = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -30,6 +30,11 @@ export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   console.log('🧭 pathname:', pathname);
 
+  // 소셜 로그인 콜백 경로는 무조건 통과
+  if (pathname === ROUTES.OAUTH_CALLBACK) {
+    return NextResponse.next();
+  }
+
   // 1. 오픈 라우트 (로그인 여부 관계없이 접근 허용)
   if (OPEN_ROUTES.includes(pathname)) {
     return NextResponse.next();

--- a/utils/attachJosa.ts
+++ b/utils/attachJosa.ts
@@ -1,0 +1,29 @@
+/**
+ * 받침 유무에 따른 조사를 자동으로 선택해주는 함수
+ * @returns
+ */
+export function attachJosa(
+  word: string,
+  josa: '을를' | '으로' | '은는' | '이가'
+): string {
+  const lastChar = word[word.length - 1]; // 마지막 글자 가져오기
+  // const code = lastChar.charCodeAt(0) - 44032; // 유니코드 기준 시작점 뺌
+  // const jong = code % 28; // 종성(받침) 추출
+  // const hasBatchim = jong !== 0; // 받침 유무 판별
+  const hasBatchim = (lastChar.charCodeAt(0) - 44032) % 28 !== 0;
+
+  switch (josa) {
+    case '을를':
+      return word + (hasBatchim ? '을' : '를');
+    case '으로':
+      // 'ㄹ' 받침은 '로'가 붙음
+      const code = lastChar.charCodeAt(0) - 44032;
+      const jong = code % 28;
+      const isRieul = jong === 8;
+      return word + (!hasBatchim || isRieul ? '로' : '으로');
+    case '은는':
+      return word + (hasBatchim ? '은' : '는');
+    case '이가':
+      return word + (hasBatchim ? '이' : '가');
+  }
+}

--- a/utils/getErrorMessageFromQuery.ts
+++ b/utils/getErrorMessageFromQuery.ts
@@ -1,0 +1,55 @@
+// src/utils/getErrorMessageFromQuery.ts
+
+import { Role } from '@/types/entities/user.entity';
+import { attachJosa } from './attachJosa';
+import { getProviderText, getRoleText, Provider } from './oauthUserHelpers';
+
+/**
+ * 소셜 로그인 시 백엔드에서 전달된 errorCode, provider, role이용해 에러 메시지를 생성
+ */
+export function getErrorMessageFromQuery(
+  searchParams: URLSearchParams
+): string {
+  const errorCode = searchParams.get('errorCode');
+
+  // provider 불일치
+  switch (errorCode) {
+    case 'PROVIDER_MISMATCH': {
+      const provider = getProviderText(
+        searchParams.get('existingProvider') as Provider
+      );
+      const role = getRoleText(searchParams.get('role') as Role);
+      return (
+        `이미 ${attachJosa(`${provider}`, '을를')} 이용해 ` +
+        `${attachJosa(`${role}`, '으로')} 가입된 이메일입니다.\n` +
+        `${attachJosa(`${provider}`, '으로')} 로그인해 주세요.`
+      );
+    }
+
+    // role 불일치
+    case 'ROLE_MISMATCH': {
+      const provider = getProviderText(
+        searchParams.get('provider') as Provider
+      );
+      const existingRole = getRoleText(
+        searchParams.get('existingRole') as Role
+      );
+      const requestedRole = getRoleText(
+        searchParams.get('requestedRole') as Role
+      );
+      return (
+        `이미 ${attachJosa(`${provider}`, '을를')} 이용해 ` +
+        `${attachJosa(`${existingRole}`, '으로')} 가입된 이메일입니다.\n` +
+        `${existingRole} 로그인 페이지에서 로그인하시거나\n` +
+        `다른 계정을 통해 ${attachJosa(`${requestedRole}`, '으로')} 가입하세요.`
+      );
+    }
+
+    // 회원가입 실패
+    case 'USER_CREATION_FAILED':
+      return '회원가입 중 문제가 발생했습니다.\n다시 시도해주세요.';
+
+    default:
+      return '알 수 없는 오류가 발생했습니다.';
+  }
+}

--- a/utils/oauthUserHelpers.ts
+++ b/utils/oauthUserHelpers.ts
@@ -1,0 +1,26 @@
+import { Role } from '@/types/entities/user.entity';
+
+export type Provider = 'local' | 'google' | 'kakao' | 'naver';
+
+/**
+ * ROLE enum -> 한글
+ */
+export function getRoleText(role: Role): string {
+  return role === 'customer' ? '고객' : '기사';
+}
+
+/**
+ * provider명을 한글로 변경
+ */
+export function getProviderText(provider: Provider): string {
+  switch (provider) {
+    case 'google':
+      return '구글';
+    case 'kakao':
+      return '카카오';
+    case 'naver':
+      return '네이버';
+    case 'local':
+      return '이메일/패스워드';
+  }
+}


### PR DESCRIPTION
### 구글, 카카오, 네이버 로그인 구현
- 구글은 배포시 도메인 네임 주소 등록 필요
  - redirect uri에 ip주소 등록 불가
- 네이버는 등록 후 심사 과정 필요(3~4일 소요)
- 개발 환경에서는 구글, 카카오 정상 작동 확인 완료

### 기존 가입된 이메일 경우, role이 다를 경우 등의 처리
- 기존 계정과 provider 일치 여부, 사용자가 가입을 의도한 role인지 여부 등에 의해 에러 처리
- 백엔드에서 errorCode와 provider, role 등을 프론트엔드의 callback 페이지로 전달하고
- 프론트엔드에서 해당 데이터를 이용해 에러 메시지 생성/표시