### PR TITLE
[조형민] 찜한 기사님 페이지네이션, 목록이 없을 때 표시할 범용 컴포넌트 추가 등 #191

### DIFF
--- a/api/favorite/favorite.api.ts
+++ b/api/favorite/favorite.api.ts
@@ -18,10 +18,17 @@ export async function createFavorite(workerId: string): Promise<void> {
   }
 }
 
-const getFavoriteWorkers = async () => {
+// 찜한 기사님 목록을 조회하는 API
+// 페이지네이션을 위해 page와 pageSize를 파라미터로 받습니다.
+
+export interface GetFavoriteWorkersParams {
+  page: number;
+  pageSize: number;
+}
+const getFavoriteWorkers = async (params: GetFavoriteWorkersParams) => {
   try {
     const url = '/favorite';
-    const response = await client.get(url);
+    const response = await client.get(url, { params });
     return response.data;
   } catch (error) {
     errorHandler(error);

--- a/api/favorite/favorite.server.api.ts
+++ b/api/favorite/favorite.server.api.ts
@@ -7,11 +7,24 @@
 
 import { API_URL } from '@/constants/env';
 import { getCookieHeader } from '@/utils/server/getCookieHeader.server';
+import { GetFavoriteWorkersParams } from './favorite.api';
 
 // - 따라서 직접 headers에 토큰(cookieHeader)을 설정해야 함
-const getFavoriteWorkersServer = async () => {
+const getFavoriteWorkersServer = async (param: GetFavoriteWorkersParams) => {
+  // 모든 값을 string으로 변환
+  const query = new URLSearchParams(
+    Object.entries(param).reduce(
+      (acc, [key, value]) => {
+        acc[key] = String(value);
+        return acc;
+      },
+      {} as Record<string, string>,
+    ),
+  ).toString();
+
   const cookieHeader = await getCookieHeader();
-  const res = await fetch(`${API_URL}/favorite`, {
+
+  const res = await fetch(`${API_URL}/favorite?${query}`, {
     method: 'GET',
     headers: {
       Cookie: cookieHeader,

--- a/app/(providers)/(root)/customer/favorites/page.tsx
+++ b/app/(providers)/(root)/customer/favorites/page.tsx
@@ -9,6 +9,13 @@ export const metadata: Metadata = {
   description: '고객이 찜한 기사님 목록을 확인하는 페이지입니다.',
 };
 
+const defaultPageParams = {
+  page: 1,
+  // 이 값이 ListFavoriteWorker에서 설정되는 값과 같으면 refetch하지 않고, 다르면 refetch됨
+  // 그러므로 데스크탑보다 모바일에서 더 자주 사용될 것으로 예상될 경우 '4'로 변경하는 것이 SSR에 유리함
+  pageSize: 6,
+};
+
 async function FavoriteWorkersPage() {
   const { queryClient } = await handleSSRPrefetch([
     // layout(ProvidersLayout)에서 user를 setQueryData로 캐싱하고 있으므로 현재 구조에선 불필요
@@ -18,8 +25,15 @@ async function FavoriteWorkersPage() {
     //   queryFn: () => userApi.getUserMeServer(accessToken),
     // },
     {
-      queryKey: ['favorites'],
-      queryFn: () => favoriteServerApi.getFavoriteWorkersServer(),
+      queryKey: [
+        'favorites',
+        { page: defaultPageParams.page, pageSize: defaultPageParams.pageSize },
+      ],
+      queryFn: () =>
+        favoriteServerApi.getFavoriteWorkersServer({
+          page: defaultPageParams.page,
+          pageSize: defaultPageParams.pageSize,
+        }),
     },
   ]);
 

--- a/assets/images/img-empty-review.svg
+++ b/assets/images/img-empty-review.svg
@@ -1,0 +1,6 @@
+<svg width="185" height="136" viewBox="0 0 185 136" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8.5 0C4.08172 0 0.5 3.58172 0.5 8V16V124C0.5 130.627 5.87258 136 12.5 136H172.5C179.127 136 184.5 130.627 184.5 124V28C184.5 21.3726 179.127 16 172.5 16H80.5L74.7112 4.42229C73.356 1.71202 70.5859 0 67.5557 0H8.5Z" fill="#E9F4FF"/>
+<circle cx="72.5" cy="64" r="6" fill="#4DA9FF"/>
+<circle cx="112.5" cy="64" r="6" fill="#4DA9FF"/>
+<path d="M75.5 92V92C85.6917 84.8059 99.3083 84.8059 109.5 92V92" stroke="#4DA9FF" stroke-width="6" stroke-linecap="round"/>
+</svg>

--- a/components/atoms/PaginationButton.tsx
+++ b/components/atoms/PaginationButton.tsx
@@ -17,10 +17,10 @@ function PaginationButton({ page, isActive = false, onClick }: PaginationButtonP
   // 버튼 스타일
   const buttonClass = clsx(
     'flex items-center justify-center rounded-md transition-colors',
-    'w-[34px] h-[34px] bg-GrayScale-50 text-base lg:w-[48px] lg:h-[48px] lg:text-lg font-semibold',
+    'w-[34px] h-[34px]  text-base lg:w-[48px] lg:h-[48px] lg:text-lg font-semibold cursor-pointer',
     {
       ' text-black': isActive,
-      'text-GrayScale-200 hover:bg-Primay-Blue-50': !isActive,
+      'text-GrayScale-200 ': !isActive,
     },
   );
 

--- a/components/molecules/AuthSocialLogIn.tsx
+++ b/components/molecules/AuthSocialLogIn.tsx
@@ -1,7 +1,7 @@
 import authApi from '@/api/auth/auth.api';
 import icSocialGoogle from '@/assets/images/ic-social-google.svg';
 import icSocialKakao from '@/assets/images/ic-social-kakao.svg';
-import icSocialNaver from '@/assets/images/ic-social-naver.svg';
+// import icSocialNaver from '@/assets/images/ic-social-naver.svg';
 import { Role } from '@/types/entities/user.entity';
 import Image from 'next/image';
 
@@ -26,12 +26,12 @@ function AuthSocialLogIn({ role }: { role: Role | null }) {
         >
           <Image src={icSocialKakao} alt="카카오" />
         </button>
-        <button
+        {/* <button
           onClick={() => authApi.handleOAuthLogin(role, 'naver')}
           className="cursor-pointer hover:opacity-70"
         >
           <Image src={icSocialNaver} alt="네이버" />
-        </button>
+        </button> */}
       </div>
     </div>
   );

--- a/components/molecules/EmptyListMessage.tsx
+++ b/components/molecules/EmptyListMessage.tsx
@@ -1,0 +1,45 @@
+import imgEmptyList from '@/assets/images/img-empty-review.svg';
+import Image from 'next/image';
+import Link from 'next/link';
+import ButtonSolid from '../atoms/ButtonSolid';
+
+interface Props {
+  message: string;
+  isUsingButton?: boolean;
+  buttonText?: string;
+  buttonLink?: string;
+}
+
+/**
+ *
+ * @param param0 message: 표시되는 메시지입니다. (e.g. "찜한 기사님이 없습니다.")
+ * @param param1 buttonText: 버튼에 표시되는 텍스트입니다. (e.g. "리뷰 작성하러 가기")
+ * @param param2 isButton: 버튼을 표시할지 여부입니다. 기본값은 false입니다.
+ * @param param3 link: 버튼 클릭 시 이동할 링크입니다. (e.g. "ROUTES.REVIEW.PENDING")
+ * @returns
+ */
+function EmptyListMessage({ message, buttonText, isUsingButton = false, buttonLink }: Props) {
+  return (
+    <div className="flex justify-center items-center">
+      <div className="flex flex-col items-center justify-center mt-20 lg:mt-30">
+        <div className="w-[110px] h-[82px] lg:w-[185px] lg:h-[136px]">
+          <Image src={imgEmptyList} alt="목록없음" layout="responsive" />
+        </div>
+        <h1 className="mt-6 mb-6 lg:mt-8 lg:mb-8 text-center text-gray-400 text-[12px] lg:text-[24px] ">
+          {message}
+        </h1>
+        {isUsingButton && (
+          <Link href={`${buttonLink}`} passHref>
+            <div className="w-[151px] h-[54px] lg:w-[180px] lg:h-[64px] ">
+              <ButtonSolid className="w-full h-full flex items-center justify-center text-[16px] lg:text-[20px]">
+                {buttonText}
+              </ButtonSolid>
+            </div>
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default EmptyListMessage;

--- a/components/organisms/ListFavoriteWorker.tsx
+++ b/components/organisms/ListFavoriteWorker.tsx
@@ -6,6 +6,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import Label from '../atoms/Label';
 import SkeletonFavoriteList from '../atoms/SkeletonFavoriteList';
+import EmptyListMessage from '../molecules/EmptyListMessage';
 import WorkerCardInLiked, { WorkerCardInLikedProps } from './WorkerCardInLiked';
 
 function ListFavoriteWorker() {
@@ -38,7 +39,7 @@ function ListFavoriteWorker() {
         </div>
       </div>
       {favorites.totalCount === 0 ? (
-        <div>찜한 기사님이 없습니다.</div>
+        <EmptyListMessage message="찜한 기사님이 없습니다." />
       ) : (
         <div className="flex justify-center">
           <div className="md:w-[600px] lg:w-[1400px] flex flex-col lg:flex-row flex-wrap gap-x-6 gap-y-6 md:gap-y-8 lg:gap-y-12">

--- a/components/organisms/ListFavoriteWorker.tsx
+++ b/components/organisms/ListFavoriteWorker.tsx
@@ -4,23 +4,66 @@ import favoriteApi from '@/api/favorite/favorite.api';
 import ROUTES from '@/constants/routes';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
+// import { useState } from 'react';
+import useDeviceSize from '@/hooks/useDeviceSize';
+import { useEffect, useRef, useState } from 'react';
 import Label from '../atoms/Label';
 import SkeletonFavoriteList from '../atoms/SkeletonFavoriteList';
 import EmptyListMessage from '../molecules/EmptyListMessage';
+import Pagination from '../molecules/Pagination';
 import WorkerCardInLiked, { WorkerCardInLikedProps } from './WorkerCardInLiked';
 
+export const PAGE_SIZE_DESKTOP = 6; // 데스크탑에서 한 페이지에 보여줄 목록 수
+export const PAGE_SIZE_MOBILE = 4; // 모바일에서 한 페이지에 보여줄 목록 수
+
 function ListFavoriteWorker() {
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE_DESKTOP); // 디바이스 감지 후 설정됨
+  const { isDeskTop } = useDeviceSize();
+
+  // 최신 page, pageSize를 안전하게 참조하기 위한 ref
+  const pageRef = useRef(page);
+  const pageSizeRef = useRef(pageSize);
+
+  // deviceSize변경으로 pageSize가 바뀔 경우의 문제 대응
+  // e.g. 데이터가 5개일 경우 모바일에서 2페이지를 보고 있다가 데스크탑으로 전환되면 2페이지에 데이터가 없음
+  useEffect(() => {
+    // 새로운 pageSize 결정
+    const newPageSize = isDeskTop ? PAGE_SIZE_DESKTOP : PAGE_SIZE_MOBILE;
+
+    // 현재 페이지에서 보고 있던 첫 데이터의 인덱스
+    const currentItemStartIndex = (pageRef.current - 1) * pageSizeRef.current;
+
+    // 새 page 계산
+    const newPage = Math.floor(currentItemStartIndex / newPageSize) + 1;
+
+    // ref 업데이트
+    pageRef.current = newPage;
+    pageSizeRef.current = newPageSize;
+
+    setPageSize(newPageSize);
+    setPage(newPage);
+
+    // 불필요한 리렌더링 혹은 무한 루프 발생 가능성때문에 page, pageSize를 그냥 사용하지 않고 ref로 관리
+  }, [isDeskTop]);
+
+  /**
+   * @description
+   * 찜한 기사님 목록 조회 API
+   * CSR 시 디바이스별 pageSize에 따라 호출됨
+   * placeholderData를 통해 이전 페이지 데이터를 유지하여 깜빡임 방지
+   */
   const {
     data: favorites,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['favorites'],
+    queryKey: ['favorites', { page, pageSize }],
     queryFn: () => {
       console.log('클라이언트 favorites 쿼리 실행됨!');
-      return favoriteApi.getFavoriteWorkers();
+      return favoriteApi.getFavoriteWorkers({ page, pageSize });
     },
-    // queryFn: favoriteApi.getFavoriteWorkers,
+    placeholderData: (prev) => prev, // keepPreviousData 대체
   });
 
   const router = useRouter();
@@ -31,6 +74,10 @@ function ListFavoriteWorker() {
 
   if (isLoading) return <SkeletonFavoriteList />;
   if (isError || !favorites) return <div>오류 발생!</div>;
+
+  const totalPages = Math.ceil(favorites.totalCount / pageSize);
+  console.log('render!!!');
+
   return (
     <div className="bg-BackGround-200 min-h-full">
       <div className="flex justify-center items-center w-full bg-GrayScale-50 h-16 lg:h-24 mb-6">
@@ -41,21 +88,31 @@ function ListFavoriteWorker() {
       {favorites.totalCount === 0 ? (
         <EmptyListMessage message="찜한 기사님이 없습니다." />
       ) : (
-        <div className="flex justify-center">
-          <div className="md:w-[600px] lg:w-[1400px] flex flex-col lg:flex-row flex-wrap gap-x-6 gap-y-6 md:gap-y-8 lg:gap-y-12">
-            {favorites.list.map((worker: WorkerCardInLikedProps) => {
-              return (
-                <div
-                  key={worker.id}
-                  className="shrink-0 cursor-pointer hover:opacity-60 active:opacity-80"
-                  onClick={() => handleClickCard(worker.id)}
-                >
-                  <WorkerCardInLiked {...worker} />
-                </div>
-              );
-            })}
+        <>
+          <div className="flex justify-center">
+            <div className="md:w-[600px] lg:w-[1400px] flex flex-col lg:flex-row flex-wrap gap-x-6 gap-y-6 md:gap-y-8 lg:gap-y-12">
+              {favorites.list.map((worker: WorkerCardInLikedProps) => {
+                return (
+                  <div
+                    key={worker.id}
+                    className="shrink-0 cursor-pointer hover:opacity-60 active:opacity-80"
+                    onClick={() => handleClickCard(worker.id)}
+                  >
+                    <WorkerCardInLiked {...worker} />
+                  </div>
+                );
+              })}
+            </div>
           </div>
-        </div>
+
+          {/* 페이지네이션 컴포넌트: 현재 페이지 및 전체 페이지 수 전달 */}
+          <Pagination
+            currentPage={page}
+            totalPages={totalPages}
+            onPageChange={setPage}
+            className="mt-8 mb-10"
+          />
+        </>
       )}
     </div>
   );

--- a/components/organisms/WorkerCardInLiked.tsx
+++ b/components/organisms/WorkerCardInLiked.tsx
@@ -56,7 +56,6 @@ function WorkerCardInLiked({
   reviewsAverage,
   reviewsCount,
 }: WorkerCardInLikedProps) {
-  console.log(experience, confirmedEstimatesCount);
   return (
     <div className="flex flex-col justify-between gap-2 shadow-xs bg-GrayScale-50 border-Line-100 border-[0.5px] rounded-2xl w-[327px] h-[150px] md:w-[600px] lg:w-[688px] lg:h-[202px] px-3.5 py-4">
       <div className="flex gap-2.5">

--- a/hooks/useDeviceSize.ts
+++ b/hooks/useDeviceSize.ts
@@ -1,11 +1,11 @@
 import { useMediaQuery } from 'react-responsive';
 
 export default function useDeviceSize() {
-  const isDeskTop = useMediaQuery({ query: '(min-width:1200px)' });
+  const isDeskTop = useMediaQuery({ query: '(min-width: 1400px)' }); // lg 이상
   const isTablet = useMediaQuery({
-    query: '(min-width:744px) and (max-width: 1199px)',
+    query: '(min-width: 744px) and (max-width: 1399px)', // md 이상 lg 미만
   });
-  const isMobile = useMediaQuery({ query: '(max-width: 743px)' });
+  const isMobile = useMediaQuery({ query: '(max-width: 743px)' }); // md 미만
 
   return { isDeskTop, isTablet, isMobile };
 }


### PR DESCRIPTION
- 네이버 소셜 로그인 버튼 삭제
  - 네이버 소셜 로그인은 인증을 받기 위해 추가 자료 제출이 필요 -> 굳이 에너지 낭비할 필요는 없다고 판단
- 목록이 없을 때 표시할 범용 컴포넌트 추가(EmptyListMessage.tsx) 
  - 사용법은 주석 참조 
  - 찜한 기사님 목록, 리뷰 목록 등의 목록 페이지에 사용 가능
- 찜한 기사님 목록에 페이지네이션 추가 
  - 페이지네이션 컴포넌트 일부 수정   
    - 배경색 삭제, cursor-pointer 적용 
  - deviceSize에 따른 pageSize적용   
    - useDeviceSize사용 -> isDeskTop 6, isMobile 4   
    - 디바이스 변경 시 보고 있던 데이터를 그대로 볼 수 있도록 로직 추가