### PR TITLE
[조형민] 프로필 이미지 수정 시 문제 해결

### DIFF
--- a/api/profiles/profiles.api.ts
+++ b/api/profiles/profiles.api.ts
@@ -35,6 +35,9 @@ const updateCustomerProfile = async (data: UpdateCustomerProfileDto) => {
     const { livingArea, services, profileImage } = data;
     const formData = new FormData();
 
+    console.log('[FORMDATA] profileImage instanceof File:', profileImage instanceof File);
+    console.log('[FORMDATA] profileImage === null:', profileImage === null);
+    console.log('[FORMDATA] profileImage === undefined:', profileImage === undefined);
     if (livingArea !== undefined) {
       formData.append('livingArea', livingArea);
     }

--- a/components/molecules/InputFile.tsx
+++ b/components/molecules/InputFile.tsx
@@ -32,6 +32,8 @@ function InputFile<
   useEffect(() => {
     if (defaultImageUrl) {
       setPickedFileUrl(defaultImageUrl);
+    } else {
+      setPickedFileUrl('');
     }
   }, [defaultImageUrl]);
 

--- a/components/templates/FormProfileCustomer.tsx
+++ b/components/templates/FormProfileCustomer.tsx
@@ -18,7 +18,7 @@ import GroupRegionSelect from '../organisms/GroupRegionSelect';
 import GroupServiceTypeSelect from '../organisms/GroupServiceTypeSelector';
 
 export interface FormProfileInput {
-  profileImage: File | null;
+  profileImage: File | null | undefined;
 }
 
 interface FormProfileCustomerProps {
@@ -31,7 +31,7 @@ interface FormProfileCustomerProps {
 
 function FormProfileCustomer({ initialProfile }: FormProfileCustomerProps) {
   const { control, handleSubmit, formState } = useForm<FormProfileInput>({
-    defaultValues: { profileImage: null },
+    defaultValues: { profileImage: undefined },
     mode: 'onTouched',
   });
 
@@ -63,6 +63,7 @@ function FormProfileCustomer({ initialProfile }: FormProfileCustomerProps) {
   );
 
   const handleClickSubmit = (inputData: FormProfileInput) => {
+    console.log('[SUBMIT] profileImage 값:', inputData.profileImage);
     if (!livingArea) return; // livingArea 없으면 안전하게 빠지기
     setIsProcessing(true);
     const data: CreateCustomerProfileDto = {


### PR DESCRIPTION
- 문제: 프로필 이미지를 수정할 때 기존 이미지가 있는 경우, 이미지를 변경하지 않았음에도 '수정하기'를 하면 이미지가 삭제되는 현상
- 원인
  - 프론트엔드: 기본값을 null로 설정하여 파일이 없는 경우와 수정하지 않은 경우 모두 백엔드에 null을 전달
  - 백엔드: 전달받는 기본값 역시 null로 설정되어 있었음
- 해결
  - 프론트엔드: 기본값을 undefinded로 변경. 명시적으로 '삭제'를 누를 경우에만 'null'을 전달
  - 백엔드: 기본값을 설정하지 않음(let profileImage;)